### PR TITLE
Fix Issue3: openalea namespace generation

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 0508b493a9dcac9577f8e7f0092b91bbc01394243dbcc562b3832d39d8686bb9
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} setup.py install"
   preserve_egg_dir: True
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,14 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} setup.py install --single-version-externally-managed --record record.txt"
+  script: "{{ PYTHON }} setup.py install"
   preserve_egg_dir: True
 
 requirements:
   host:
     - python
     - setuptools
+    - six
   run:
     - python
     - setuptools


### PR DESCRIPTION
Fix #3 by removing flags --single-version-externally-managed.
Add six as host (used in setup.py install-requires).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Close #3 
<!--
Please add any other relevant info below:
-->
