### PR TITLE
Replace path.py dependency by path package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 34c9c7dc123476dad6d41e528f32e56ca5bf57fa1add0916821b0ab8fbc93008
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} setup.py install
   preserve_egg_dir: true
 
@@ -40,9 +40,9 @@ about:
     Python 3.7+. It is an extension of setuptools.
     Features :
 
-        Install shared libraries, include and libs in eggs
-        Support 'develop' command
-        Call SCons or CMake scripts in setup.py
+      * Install shared libraries, include and libs in eggs
+      * Support 'develop' command
+      * Call SCons or CMake scripts in setup.py
 
   dev_url: https://github.com/openalea/deploy
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   run:
     - python
     - setuptools
-    - path.py
+    - path
 
 
 test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
The module path.py seems outdated. Replace it by path.